### PR TITLE
fix: update entrypoint filename

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -25,4 +25,4 @@ inputs:
 
 runs:
   using: 'node12'
-  main: 'dist/main.js'
+  main: 'dist/index.js'


### PR DESCRIPTION
The name of the node entrypoint should be `dist/index.js` instead of `dist/main.js`, because that's what exists in the repo.
Using `dist/main.js` produces an error, because such file doesn't exist.